### PR TITLE
allow list or string in concat arguments

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['20', 'latest']
+        node-version: ['16', '18', '20', 'latest']
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npm test

--- a/README.md
+++ b/README.md
@@ -1,8 +1,171 @@
 # Array for string literals
 
-For runtime type safe array of string literal without compilation.
+Typed array of string literals working at runtime without typescript compilation.
+
+Useful for types constructs that can be used at runtime.
 
 *If you code in typescript, you probably don't need any of this.*
+
+## Overview
+
+The StringList class extends the Array interface types to work with string literals.
+
+- immutable: methods that mutate the array in place like push, pop, shift, unshift, splice are omitted.
+
+- inference: concat, toReversed and toSorted methods are implemented to return a new frozen instance and will infer the new values.
+  - the concat method parameters types has been updated to accept strings literals and/or instances of StringList.
+
+- search methods: includes, indexOf, find, every, .. and others search methods types are updated to prevent type errors when comparing with non-literals strings.
+
+- not chainable or iterator: map / filter / reduce / flat / values / keys / entries are the same as the native Array, and will return the type defined by the native method.
+
+- no changes is made to the execution of the methods to minimize maintenance, bugs or breaking changes. Types on the other hand are subjects to bugs and breaking changes, or incompatibilities with typescript and es versions.
+
+- `mutable():string[]` has been implemented to return a copy of the underlying array as string[].
+
+- more methods relevants to string literals and type constructs could be added along the way.
+
+```js
+import { stringList } from 'string-literal-list';
+
+let v = stringList("foo", "bar", ...) => SL<"foo" | "bar">;
+
+v.includes(anyValue) => boolean;
+
+v.withPrefix('prefix.') => SL<"prefix.foo" | "prefix.bar">
+
+v.withSuffix('.suffix') => SL<"foo.suffix" | "bar.suffix">
+
+v.concat('zing', 'boom', stringList('zig', 'zag')) => SL<"foo" | "bar" | "zing" | "boom" | "zig" | "zag">;
+
+```
+
+## Installation
+
+```bash
+npm install --save string-literal-list
+```
+
+```bash
+yarn add string-literal-list
+```
+
+### Usage
+
+```js
+import { stringList } from 'string-literal-list';
+
+const list = stringList(
+  'foo',
+  'bar',
+);
+// SL<"foo" | "bar">;
+
+const prefixed = list.withPrefix('prefix.');
+// SL<"prefix.foo" | "prefix.bar">;
+
+const suffixed = list.withSuffix('.suffix');
+// SL<"foo.suffix" | "bar.suffix">;
+
+const concat = prefixed.concat(...suffixed);
+// SL<"prefix.foo" | "prefix.bar" | "foo.suffix" | "bar.suffix">;
+
+const bothWay = list.withPrefix('data.').withSuffix('.ext');
+// SL<"data.foo.ext" | "data.bar.ext">;
+
+/** @type {any|unknown|'notInTheList'} */
+let val;
+list.includes(val); // No type error just boolean result.
+// list implements similar fix for indexOf, lastIndexOf, filter, some, every, findIndex and find methods.
+```
+
+#### list.concat(...(string|StringList)[])
+
+`list.concat()` accept only string and StringList as arguments to enable inference.
+If a native array is passed the string literals won't be inferred.
+
+```js
+// OK
+list.concat('zing', 'foo', stringList('gurgle', 'doink'));
+=> SL<"foo" | "bar" | 'zing' | 'gurgle' | 'doink'>
+
+// Not OK.
+list.concat('zing', 'foo', ['boom', 'bar']);
+// => Argument of type '"foo"' is not assignable to parameter of type '"zing" | ILiterals<"zing">'.ts(2345)
+```
+
+### filter / map / reduce and other array methods
+
+The results of those methods will result in type loose `string[]` or returned `U[]` for map / reduce.
+
+### References
+
+See the namespace `sl.specs` (./types.d.ts) to know which methods are available and specific type overrides.
+
+```js
+namespace specs {
+  export type OmitedMutableMethod =
+    | 'push'
+    | 'slice'
+    | 'sort'
+    | 'unshift'
+    | 'shift'
+    | 'copyWithin'
+    | 'pop'
+    | 'fill'
+    | 'splice'
+    | 'reverse';
+
+  /**
+   * @description
+   * The execution is delegated to the Array instance methods.
+   * The implementation uses the result to return a new readonly list instance.
+   */
+  type ImplementedMethod =
+    | 'concat'
+    | 'withPrefix'
+    | 'withSuffix'
+    | 'toReversed'
+    | 'toSorted';
+
+  /**
+   * @description
+   * The type of these methods are updated to fix ts value comparison between `T` and `string`.
+   */
+  type NativeMethodWithTypeOverride =
+    | 'at'
+    | 'indexOf'
+    | 'lastIndexOf'
+    | 'includes'
+    | 'toSpliced'
+    | 'length'
+    | 'find'
+    | 'findIndex'
+    | 'some'
+    | 'every'
+    | 'filter'
+    | 'with';
+
+  /**
+   * @description
+   * No type or any overrides.
+   * filter, map, flatMap, flat will result in the original array type.
+   */
+  type NativeMethod =
+    | 'join'
+    | 'toLocaleString'
+    | 'toString'
+    | 'entries'
+    | 'keys'
+    | 'values'
+    | 'forEach'
+    | 'map'
+    | 'reduce'
+    | 'reduceRight'
+    | 'flat'
+    | 'flatMap';
+}
+```
 
 ## Why?
 
@@ -10,12 +173,12 @@ The javascript Array interface is not designed to work with constant string lite
 
 The methods like concat, or includes will expect only the constants as argument, which makes a method like includes() useless, and others build method annoying to type when constructing the constants.
 
-### The js workarounds
+### workarounds
 
 - includes(): using mapped object in your code instead of the array, e.g. `!!MY_LIST_AS_unnecessary_MAP[val]`, but if you want type safety this means no .concat(), no .includes(), no iteration without creating new variables.
 - concat(): just concatenate your workarounds into a single type. e.g. `/** @type {((keyof typeof MAP_A) | MAPPED_FROM_MAP_B)[]} */` not solving any issues with the underlying unusable array methods.
 
-### Code demonstrating the problem
+### Code showing the problem using typed array
 
 ```js
 // Not typed.
@@ -61,151 +224,4 @@ lit.concat(val);
 //     Argument of type 'string' is not assignable to parameter of type 'ConcatArray<"foo" | "bar">'.
 //   Overload 2 of 2, '(...items: ("foo" | "bar" | ConcatArray<"foo" | "bar">)[]): ("foo" | "bar")[]', gave the following error.
 //     Argument of type 'string' is not assignable to parameter of type '"foo" | "bar" | ConcatArray<"foo" | "bar">'.ts(2769)
-```
-
-## The "solution"
-
-stringList extends the native Array types to works with string literals.
-it omits the methods that mutate the array in place like push, pop, shift, unshift, splice.
-
-### Overview
-
-```js
-import { stringList } from 'string-literal-list';
-
-let v = stringList("foo", "bar", ...) => StringList<"foo" | "bar">;
-
-v.includes(anyValue) => boolean;
-
-v.withPrefix('prefix.') => StringList<"prefix.foo" | "prefix.bar">
-
-v.withSuffix('.suffix') => StringList<"foo.suffix" | "bar.suffix">
-
-v.concat('zing', 'boom') => StringList<"foo" | "bar" | "zing" | "boom">
-
-```
-
-## Installation
-
-```bash
-npm install --save string-literal-list
-```
-
-```bash
-yarn add string-literal-list
-```
-
-### Usage
-
-```js
-import { stringList } from 'string-literal-list';
-
-const list = stringList(
-  'foo',
-  'bar',
-);
-// literals types are inferred
-// list: stringList<"foo" | "bar">;
-
-const prefixed = list.withPrefix('prefix.');
-// stringList<"prefix.foo" | "prefix.bar">;
-
-const suffixed = list.withSuffix('.suffix');
-// stringList<"foo.suffix" | "bar.suffix">;
-
-const concat = prefixed.concat(...suffixed);
-// stringList<"prefix.foo" | "prefix.bar" | "foo.suffix" | "bar.suffix">;
-
-const bothWay = list.withPrefix('data.').withSuffix('.ext');
-// stringList<"data.foo.ext" | "data.bar.ext">;
-
-/** @type {any|unknown|'notInTheList'} */
-let val;
-list.includes(val); // No type error just boolean result.
-// list implements similar fix for indexOf, lastIndexOf, filter, some, every, findIndex and find methods.
-```
-
-#### list.concat vs array.concat
-
-list.concat require string literals arguments to enable inference.
-
-```js
-// OK
-list.concat('zing', 'foo');
-
-// ERROR
-list.concat(['zing', 'foo']);
-```
-
-### filter / map / reduce and other array methods
-
-The results of those methods will result in type loose `string[]` or returned `U[]` for map / reduce.
-
-### References
-
-See the namespace `sl.specs` (./types.d.ts) to know which methods are available and specific type overrides.
-
-```js
-namespace specs {
-  export type OmitedMutableMethod =
-    | 'push'
-    | 'slice'
-    | 'sort'
-    | 'unshift'
-    | 'shift'
-    | 'copyWithin'
-    | 'pop'
-    | 'fill'
-    | 'splice'
-    | 'reverse';
-
-  /**
-   * @description
-   * These methods are implemented in StringList class to change the returned type to IStringList.
-   * The execution is delegated to the Array instance and the result is used to construct the returned IStringList.
-   */
-  type ImplementedMethod =
-    | 'concat'
-    | 'withPrefix'
-    | 'withSuffix'
-    | 'toReversed'
-    | 'toSorted';
-
-  /**
-   * @description
-   * These methods only get a type override to fix the comparison between `T` and `string`.
-   */
-  type NativeMethodWithTypeOverride =
-    | 'at'
-    | 'indexOf'
-    | 'lastIndexOf'
-    | 'includes'
-    | 'toSpliced'
-    | 'length'
-    | 'find'
-    | 'findIndex'
-    | 'some'
-    | 'every'
-    | 'filter';
-
-  /**
-   * @description
-   * These methods are the same are coming from the Array instance.
-   * No type overrides here.
-   * They will return the original type, (e.g. mutable array in case of map / reduce and other transforming methods.)
-   */
-  type NativeMethod =
-    | 'join'
-    | 'toLocaleString'
-    | 'toString'
-    | 'entries'
-    | 'keys'
-    | 'values'
-    | 'forEach'
-    | 'map'
-    | 'reduce'
-    | 'reduceRight'
-    | 'flat'
-    | 'flatMap';
-}
 ```

--- a/StringLiteralList.d.ts
+++ b/StringLiteralList.d.ts
@@ -1,12 +1,16 @@
 import { sl } from './types.js';
 
+interface ILiterals<T extends unknown = null> {
+  readonly literal: T;
+}
+
 export interface IStringList<T extends unknown>
   extends Omit<
     Array<T>,
     | sl.specs.ImplementedMethod
     | sl.specs.OmitedMutableMethod
     | sl.specs.NativeMethodWithTypeOverride
-  > {
+  >, ILiterals<T> {
   // Custom Methods
   withPrefix<P extends string>(
     prefix: P,
@@ -19,9 +23,8 @@ export interface IStringList<T extends unknown>
   // Implemented methods to return the frozen array, typed as IStringList.
   toSorted(compareFn?: (a: T, b: T) => number): IStringList<T>;
   toReversed(): IStringList<T>;
-  concat<PP extends T, P extends string = string>(
-    ...arg: P[]
-  ): IStringList<Record<P, P>[keyof Record<P, P>] | PP>;
+
+  concat<PP extends T, S extends string>(...arg: (ILiterals<S> | S)[]): Readonly<IStringList<PP | S>>;
 
   // Readonly overrides
   readonly length: number;
@@ -68,6 +71,7 @@ export interface IStringList<T extends unknown>
   ): boolean;
 
   // Return Type overrides
+  with(index: number, value: any): string[];
   filter<S extends T>(
     predicate: (value: T, index: number, array: IStringList<T>) => value is S,
     thisArg?: any,
@@ -79,7 +83,7 @@ export interface IStringList<T extends unknown>
   toSpliced(start: number, deleteCount: number, ...items: string[]): string[];
 }
 
-export class StringLiteralList<T extends string> {
+export class SL<T extends string> {
   constructor(...list: T[]);
 }
 

--- a/StringLiteralList.js
+++ b/StringLiteralList.js
@@ -1,32 +1,28 @@
-export class StringLiteralList extends Array {
-  concat() {
-    return Object.freeze(
-      new StringLiteralList(...super.concat.apply(this, arguments)),
-    );
+import 'core-js/actual/array/to-reversed.js';
+import 'core-js/actual/array/to-sorted.js';
+import 'core-js/actual/array/to-spliced.js';
+import 'core-js/actual/array/with.js';
+
+export class SL extends Array {
+  internal = undefined;
+  concat(...args) {
+    return Object.freeze(new SL(...super.concat.apply(this, args.flat())));
   }
 
   toSorted() {
-    return Object.freeze(
-      new StringLiteralList(...super.toSorted.apply(this, arguments)),
-    );
+    return Object.freeze(new SL(...super.toSorted.apply(this, arguments)));
   }
 
   toReversed() {
-    return Object.freeze(
-      new StringLiteralList(...super.toReversed.apply(this, arguments)),
-    );
+    return Object.freeze(new SL(...super.toReversed.apply(this, arguments)));
   }
 
   withPrefix(prefix) {
-    return Object.freeze(
-      new StringLiteralList(...super.map((e) => `${prefix}${e}`)),
-    );
+    return Object.freeze(new SL(...super.map((e) => `${prefix}${e}`)));
   }
 
   withSuffix(suffix) {
-    return Object.freeze(
-      new StringLiteralList(...super.map((e) => `${e}${suffix}`)),
-    );
+    return Object.freeze(new SL(...super.map((e) => `${e}${suffix}`)));
   }
 
   // Get the native array
@@ -63,6 +59,10 @@ export class StringLiteralList extends Array {
     const mut = this.mutable();
     return mut.toSpliced.apply(mut, arguments);
   }
+  with() {
+    const mut = this.mutable();
+    return mut.with.apply(mut, arguments);
+  }
 }
 
 export const ARRAY_IN_PLACE_MUTATION = Object.freeze({
@@ -78,7 +78,7 @@ export const ARRAY_IN_PLACE_MUTATION = Object.freeze({
   reverse: 'reverse',
 });
 Object.values(ARRAY_IN_PLACE_MUTATION).forEach((el) => {
-  StringLiteralList.prototype[el] = () => {
+  SL.prototype[el] = () => {
     throw new Error(`Array method ${el} is not supported by StringLiteralList`);
   };
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,24 +1,28 @@
 {
   "name": "string-literal-list",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "string-literal-list",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
+      "dependencies": {
+        "core-js": "^3.36.0"
+      },
       "devDependencies": {
-        "eslint": "^8.57.0",
-        "eslint-config-prettier": "^9.1.0",
-        "eslint-config-standard": "^17.1.0",
-        "eslint-plugin-import": "^2.29.1",
-        "prettier": "^3.2.5",
-        "tap": "^18.7.0",
+        "eslint": "latest",
+        "eslint-config-prettier": "latest",
+        "eslint-config-standard": "latest",
+        "eslint-plugin-import": "latest",
+        "husky": "latest",
+        "prettier": "latest",
+        "tap": "latest",
         "typescript": "latest"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=16"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1891,6 +1895,16 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.36.0.tgz",
+      "integrity": "sha512-mt7+TUBbTFg5+GngsAxeKBTl5/VS0guFeJacYge9OmHb+m058UwwIm41SE9T4Den7ClatV57B6TYTuJ0CX1MAw==",
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -3262,6 +3276,21 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.0.11",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.11.tgz",
+      "integrity": "sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==",
+      "dev": true,
+      "bin": {
+        "husky": "bin.mjs"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "string-literal-list",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "an array for string literal",
   "main": "stringList.js",
   "types": "stringList.d.ts",
@@ -10,17 +10,18 @@
     }
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=16"
   },
-  "packageManager": "npm@10.5.0+sha256.17ca6e08e7633b624e8f870db81a78f46afe119de62bcaf0a7407574139198fc",
+  "packageManager": "npm@10.5.0",
   "license": "MIT",
   "scripts": {
     "test": "npm run lint:ci && npm run test:checkJs && npm run test:unit",
-    "test:unit": "tap run && tap report --show-full-coverage",
+    "test:unit": "tap run -R terse && tap report --show-full-coverage",
     "test:checkJs": "tsc --checkJs --project ./jsconfig.json",
     "prettier": "prettier --write \"**/*.{js,ts}\"",
     "lint": "eslint --fix \"./*.js\"",
-    "lint:ci": "eslint . --ext .js"
+    "lint:ci": "eslint . --ext .js",
+    "prepare": "husky"
   },
   "author": "Vincent Baronnet",
   "type": "module",
@@ -29,12 +30,16 @@
     "url": "https://github.com/rawpixel-vincent/string-list.git"
   },
   "devDependencies": {
-    "eslint": "^8.57.0",
-    "eslint-config-prettier": "^9.1.0",
-    "eslint-config-standard": "^17.1.0",
-    "eslint-plugin-import": "^2.29.1",
-    "prettier": "^3.2.5",
-    "tap": "^18.7.0",
+    "eslint": "latest",
+    "eslint-config-prettier": "latest",
+    "eslint-config-standard": "latest",
+    "eslint-plugin-import": "latest",
+    "husky": "latest",
+    "prettier": "latest",
+    "tap": "latest",
     "typescript": "latest"
+  },
+  "dependencies": {
+    "core-js": "^3.36.0"
   }
 }

--- a/stringList.d.ts
+++ b/stringList.d.ts
@@ -1,5 +1,5 @@
 import { IStringList } from './StringLiteralList.js';
 
-export function stringList<T extends string>(
+export function stringList<T extends string = never>(
   ...strings: T[]
 ): Readonly<IStringList<Record<T, T>[T]>>;

--- a/stringList.js
+++ b/stringList.js
@@ -1,6 +1,6 @@
 /// <reference path="types.d.ts" />
 
-import { StringLiteralList } from './StringLiteralList.js';
+import { SL } from './StringLiteralList.js';
 
 /** @type {import('./stringList.js').stringList} */
 export function stringList(...strings) {
@@ -8,5 +8,5 @@ export function stringList(...strings) {
     throw new Error(`Not a string in stringList ${strings[0]}`);
   }
   // @ts-expect-error[2322]
-  return Object.freeze(new StringLiteralList(...strings));
+  return Object.freeze(new SL(...strings));
 }

--- a/stringList.test.js
+++ b/stringList.test.js
@@ -1,27 +1,23 @@
 import t from 'tap';
 
-import {
-  StringLiteralList,
-  ARRAY_IN_PLACE_MUTATION,
-} from './StringLiteralList.js';
+import { SL, ARRAY_IN_PLACE_MUTATION } from './StringLiteralList.js';
 
 import { stringList } from './stringList.js';
 
 /**
- * @template {string} TS
- * @template {import('./StringLiteralList.js').IStringList<TS>} T
  * @param {import('tap').Test} st
- * @param {T} list
- * @param {...TS} values
+ * @param {any} list
+ * @param {...string} values
  */
 const testExpectedArrayValues = (st, list, ...values) => {
-  st.ok(list.constructor.name === 'StringLiteralList');
+  st.ok(list.constructor.name === 'SL');
   st.notOk(list.constructor.name === 'Array');
-  st.match(list, new StringLiteralList(...values));
+  st.match(list, new SL(...values));
   st.match(list, {
     length: values.length,
   });
   st.match([...list], values);
+  st.match(JSON.stringify([...list]), JSON.stringify(values));
   st.match([...list.keys()], [...values.keys()]);
   st.match([...list.values()], values);
   st.match([...list.entries()], [...values.entries()]);
@@ -30,7 +26,9 @@ const testExpectedArrayValues = (st, list, ...values) => {
     st.ok(list.includes(value));
     st.ok(list.indexOf(values[i]) === i);
     st.ok(list.at(i) === value);
-    st.ok(list.findLastIndex((v) => v === value) === i);
+    if (Array.prototype.findLastIndex) {
+      st.ok(list.findLastIndex((v) => v === value) === i);
+    }
     st.ok(list.findIndex((v) => v === value) === i);
     st.ok(list.some((v) => v === value) === true);
     st.ok(list.every((v) => v === value) === (list.length === 1));
@@ -41,22 +39,23 @@ const testExpectedArrayValues = (st, list, ...values) => {
 };
 
 /**
- * @template {string} TS
- * @template {import('./StringLiteralList.js').IStringList<TS>} T
  * @param {import('tap').Test} st
- * @param {T} list
- * @param {...TS} values
+ * @param {any} list
+ * @param {...string} values
  */
 const testEscapingFromStringList = (st, list, ...values) => {
-  st.ok(list.constructor.name === 'StringLiteralList');
+  st.ok(list.constructor.name === 'SL');
 
   // map()
   const fromMap = list.map((el) => el);
   st.ok(fromMap.constructor.name === 'Array');
   st.ok(fromMap.length === list.length);
   st.match(fromMap, list);
+  st.match(JSON.stringify([...list]), JSON.stringify(fromMap));
   if (values.length > 0) {
-    list.map((e) => e.toUpperCase()).includes(values[0].toUpperCase());
+    list
+      .map((e) => typeof e === 'string' && e.toUpperCase())
+      .includes(values[0].toUpperCase());
   }
 
   // filter()
@@ -64,36 +63,62 @@ const testEscapingFromStringList = (st, list, ...values) => {
   st.ok(fromFilter.constructor.name === 'Array');
   st.ok(fromFilter.length === list.length);
   st.match(fromFilter, list);
+  st.match(JSON.stringify([...list]), JSON.stringify(fromFilter));
 
   // reduce()
   const fromReduce = list.reduce((acc, el) => acc.concat(el), []);
   st.ok(fromReduce.constructor.name === 'Array');
   st.ok(fromReduce.length === list.length);
   st.match(fromReduce, list);
+  st.match(JSON.stringify([...list]), JSON.stringify(fromReduce));
 
   // reduceRight()
   const fromReduceRight = list.reduceRight((acc, el) => acc.concat(el), []);
   st.ok(fromReduceRight.constructor.name === 'Array');
   st.ok(fromReduceRight.length === list.length);
   st.match(fromReduceRight.reverse(), list);
+  st.match(JSON.stringify([...list]), JSON.stringify(fromReduceRight));
 
   // flat()
   const fromFlat = list.flat();
   st.ok(fromFlat.constructor.name === 'Array');
   st.ok(fromFlat.length === list.length);
   st.match(fromFlat, list);
+  st.match(JSON.stringify([...list]), JSON.stringify(fromFlat));
 
   // flatMap()
   const fromFlatMap = list.flatMap((el) => [el]);
   st.ok(fromFlatMap.constructor.name === 'Array');
   st.ok(fromFlatMap.length === list.length);
   st.match(fromFlatMap, list);
+  st.match(JSON.stringify([...list]), JSON.stringify(fromFlatMap));
 
   // toSpliced()
   const fromSpliced = list.toSpliced(0, 0);
   st.ok(fromSpliced.constructor.name === 'Array');
   st.ok(fromSpliced.length === list.length);
   st.match(fromSpliced, list);
+  st.match(JSON.stringify([...list]), JSON.stringify(fromSpliced));
+
+  // with()
+  if (values.length > 0) {
+    const fromWith = list.with(0, 'a');
+    st.ok(fromWith.constructor.name === 'Array');
+    st.ok(fromWith.length === list.length);
+    st.notMatch(fromWith, list);
+    st.notMatch(fromWith, values);
+    st.match([...fromWith.slice(1)], values.slice(1));
+    st.match(fromWith.concat(...list), fromWith);
+  } else {
+    if (!process.version.match(/^v1[2-8]\./)) {
+      st.throws(() => list.with(0, 'a'), new Error('Invalid index : 0'));
+    } else {
+      st.throws(
+        () => list.with(0, 'a').slice(1),
+        new RangeError('Incorrect index'),
+      );
+    }
+  }
 };
 
 t.test('empty stringList', (t) => {
@@ -101,6 +126,19 @@ t.test('empty stringList', (t) => {
   t.match([...list], []);
   testExpectedArrayValues(t, list);
   testEscapingFromStringList(t, list);
+  t.doesNotThrow(() => {
+    t.ok(list.concat().length === 0);
+    t.ok(list.withPrefix('.').length === 0);
+    t.ok(list.withSuffix('.').length === 0);
+    t.ok(list.toSorted().length === 0);
+    t.ok(list.toReversed().length === 0);
+  });
+  const notEmpty = list.concat('a', 'b', 'c');
+  t.ok(notEmpty.length === 3);
+  t.ok(list.length === 0);
+  t.notMatch(list, notEmpty);
+  t.match(notEmpty, stringList('a', 'b', 'c'));
+
   t.end();
 });
 
@@ -136,6 +174,48 @@ t.test("concat('zing', 'boom')", (t) => {
   const list = stringList('foo', 'bar').concat('zing', 'boom');
   testExpectedArrayValues(t, list, 'foo', 'bar', 'zing', 'boom');
   testEscapingFromStringList(t, list, 'foo', 'bar', 'zing', 'boom');
+  t.end();
+});
+
+t.test("concat(stringList, stringList, 'a', 'b', 'c', 'd')", (t) => {
+  const a = stringList('abc', 'def', 'ghi');
+  const b = stringList('jkl', 'mno', 'pqr');
+  const c = stringList('stu', 'vwx', 'yz');
+  const list = a.concat(b, c, 'a', 'b', 'c', 'd');
+  testExpectedArrayValues(
+    t,
+    list,
+    'abc',
+    'def',
+    'ghi',
+    'jkl',
+    'mno',
+    'pqr',
+    'stu',
+    'vwx',
+    'yz',
+    'a',
+    'b',
+    'c',
+    'd',
+  );
+  testEscapingFromStringList(
+    t,
+    list,
+    'abc',
+    'def',
+    'ghi',
+    'jkl',
+    'mno',
+    'pqr',
+    'stu',
+    'vwx',
+    'yz',
+    'a',
+    'b',
+    'c',
+    'd',
+  );
   t.end();
 });
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -45,7 +45,8 @@ export namespace sl {
       | 'findIndex'
       | 'some'
       | 'every'
-      | 'filter';
+      | 'filter'
+      | 'with';
 
     /**
      * @description
@@ -69,4 +70,4 @@ export namespace sl {
   }
 }
 
-export {};
+export { };


### PR DESCRIPTION
- allow list or string in concat arguments
- add support for node >=16
- fix the literals type when updating an empty list
- rename the StringList class to SL
- add tests for empty lists, older node versions and concat of list and strings